### PR TITLE
Input history of commanded yaw offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ Source/Obj_lin64
 *.mod
 Source/x64/
 Source/Release/
-Build/
+*build*
+Makefile
+
 
 # Archive
 Scripts/CompileDISCONHereCopyRun\.cmd
@@ -18,3 +20,6 @@ Scripts/CompileDISCONHereCopyRun\.cmd
 *~
 .DS_Store
 *.u2d
+
+# vs code
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Source/Obj_lin64
 Source/x64/
 Source/Release/
 Build/
+*build*
 
 # Archive
 Scripts/CompileDISCONHereCopyRun\.cmd
@@ -18,6 +19,7 @@ Scripts/CompileDISCONHereCopyRun\.cmd
 *~
 .DS_Store
 *.u2d
+*.vscode
 
 # Intel fortran
 *.i90

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Scripts/CompileDISCONHereCopyRun\.cmd
 *~
 .DS_Store
 *.u2d
+
+# Intel fortran
+*.i90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-project(ROSCO VERSION 2.1.0 LANGUAGES Fortran)
+project(ROSCO VERSION 2.1.1 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-project(ROSCO VERSION 2.0.4 LANGUAGES Fortran)
+project(ROSCO VERSION 2.1.0 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(APPLE OR UNIX)
   endif()
 elseif(WIN32 AND MINGW)
   # Ensure static linking to avoid requiring Fortran runtime dependencies
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -static-libgcc -static-libgfortran -static")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-0 -static-libgcc -static-libgfortran -static  -fdefault-real-8 -fdefault-double-8")
 endif()
 
 set(SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
-project(ROSCO VERSION 2.0.3 LANGUAGES Fortran)
+project(ROSCO VERSION 2.0.4 LANGUAGES Fortran)
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods")
 

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -187,16 +187,16 @@ CONTAINS
                 
                 ! Update Jacobian
                 F(1,1) = A_op
-                F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(2,2) = PI * v_m/(2.0*L)
-                F(2,3) = PI * v_t/(2.0*L)
-
+                F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * 1/om_r * 3.0 * Cp_op * v_h**2.0
+                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * 1/om_r * 3.0 * Cp_op * v_h**2.0
+                F(2,2) = - PI * v_m/(2.0*L)
+                F(2,3) = - PI * v_t/(2.0*L)
+                
                 ! Update process noise covariance
                 Q(1,1) = 0.00001
                 Q(2,2) =(PI * (v_m**3.0) * (Ti**2.0)) / L
                 Q(3,3) = (2.0**2.0)/600.0
-
+                
                 ! Prediction update
                 Tau_r = AeroDynTorque(LocalVar,CntrPar,PerfData)
                 a = PI * v_m/(2.0*L)

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -159,7 +159,7 @@ CONTAINS
         ! Extended Kalman Filter (EKF) implementation
         ELSEIF (CntrPar%WE_Mode == 2) THEN
             ! Define contant values
-            L = 2.0 * CntrPar%WE_BladeRadius
+            L = 6.0 * CntrPar%WE_BladeRadius
             Ti = 0.18
             R_m = 0.02
             H = RESHAPE((/1.0 , 0.0 , 0.0/),(/1,3/))

--- a/src/ControllerBlocks.f90
+++ b/src/ControllerBlocks.f90
@@ -132,14 +132,14 @@ CONTAINS
         REAL(8)                 :: a                ! wind variance
         REAL(8)                 :: lambda           ! tip-speed-ratio [rad]
         !           - Covariance matrices
-        REAL(8), DIMENSION(2,2)         :: F        ! First order system jacobian 
-        REAL(8), DIMENSION(2,2), SAVE   :: P        ! Covariance estiamte 
-        REAL(8), DIMENSION(1,2)         :: H        ! Output equation jacobian 
-        REAL(8), DIMENSION(2,1), SAVE   :: xh       ! Estimated state matrix
-        REAL(8), DIMENSION(2,1)         :: dxh      ! Estimated state matrix deviation from previous timestep
-        REAL(8), DIMENSION(2,2)         :: Q        ! Process noise covariance matrix
+        REAL(8), DIMENSION(3,3)         :: F        ! First order system jacobian 
+        REAL(8), DIMENSION(3,3), SAVE   :: P        ! Covariance estiamte 
+        REAL(8), DIMENSION(1,3)         :: H        ! Output equation jacobian 
+        REAL(8), DIMENSION(3,1), SAVE   :: xh       ! Estimated state matrix
+        REAL(8), DIMENSION(3,1)         :: dxh      ! Estimated state matrix deviation from previous timestep
+        REAL(8), DIMENSION(3,3)         :: Q        ! Process noise covariance matrix
         REAL(8), DIMENSION(1,1)         :: S        ! Innovation covariance 
-        REAL(8), DIMENSION(2,1), SAVE   :: K        ! Kalman gain matrix
+        REAL(8), DIMENSION(3,1), SAVE   :: K        ! Kalman gain matrix
         REAL(8)                         :: R_m      ! Measurement noise covariance [(rad/s)^2]
         
         REAL(8), DIMENSION(3,1), SAVE   :: B
@@ -162,19 +162,19 @@ CONTAINS
             L = 6.0 * CntrPar%WE_BladeRadius
             Ti = 0.18
             R_m = 0.02
-            H = RESHAPE((/1.0 , 0.0/),(/1,2/))
+            H = RESHAPE((/1.0 , 0.0 , 0.0/),(/1,3/))
             ! Define matrices to be filled
-            F = RESHAPE((/0.0, 0.0, 0.0, 0.0/),(/2,2/))
-            Q = RESHAPE((/0.0, 0.0, 0.0, 0.0/),(/2,2/))
+            F = RESHAPE((/0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0/),(/3,3/))
+            Q = RESHAPE((/0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0/),(/3,3/))
             IF (LocalVar%iStatus == 0) THEN
                 ! Initialize recurring values
                 om_r = LocalVar%RotSpeedF
-                ! v_t = 0.0
-                ! v_m = LocalVar%HorWindV
+                v_t = 0.0
+                v_m = LocalVar%HorWindV
                 v_h = LocalVar%HorWindV
-                xh = RESHAPE((/om_r, v_h/),(/2,1/))
-                P = RESHAPE((/0.01, 0.0, 0.0, 0.01/),(/2,2/))
-                K = RESHAPE((/0.0,0.0,0.0/),(/2,1/))
+                xh = RESHAPE((/om_r, v_t, v_m/),(/3,1/))
+                P = RESHAPE((/0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 1.0/),(/3,3/))
+                K = RESHAPE((/0.0,0.0,0.0/),(/3,1/))
                 
             ELSE
                 ! Find estimated operating Cp and system pole
@@ -188,21 +188,21 @@ CONTAINS
                 ! Update Jacobian
                 F(1,1) = A_op
                 F(1,2) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                ! F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
-                F(2,2) = PI * v_h/(2.0*L)
-                ! F(2,3) = PI * v_t/(2.0*L)
+                F(1,3) = 1.0/(2.0*CntrPar%WE_Jtot) * CntrPar%WE_RhoAir * PI *CntrPar%WE_BladeRadius**2.0 * Cp_op * 3.0 * v_h**2.0 * 1.0/om_r
+                F(2,2) = PI * v_m/(2.0*L)
+                F(2,3) = PI * v_t/(2.0*L)
 
                 ! Update process noise covariance
                 Q(1,1) = 0.00001
-                Q(2,2) =(PI * (v_h**3.0) * (Ti**2.0)) / L + (2.0**2.0)/600.0
-                ! Q(3,3) = (2.0**2.0)/600.0
+                Q(2,2) =(PI * (v_m**3.0) * (Ti**2.0)) / L
+                Q(3,3) = (2.0**2.0)/600.0
 
                 ! Prediction update
                 Tau_r = AeroDynTorque(LocalVar,CntrPar,PerfData)
-                a = PI * v_h/(2.0*L)
+                a = PI * v_m/(2.0*L)
                 dxh(1,1) = 1.0/CntrPar%WE_Jtot * (Tau_r - CntrPar%WE_GearboxRatio * LocalVar%VS_LastGenTrqF)
-                dxh(2,1) = -a*v_h
-                ! dxh(3,1) = 0.0
+                dxh(2,1) = -a*v_t
+                dxh(3,1) = 0.0
                 
                 xh = xh + LocalVar%DT * dxh ! state update
                 P = P + LocalVar%DT*(MATMUL(F,P) + MATMUL(P,TRANSPOSE(F)) + Q - MATMUL(K * R_m, TRANSPOSE(K))) 
@@ -216,11 +216,10 @@ CONTAINS
                 
                 ! Wind Speed Estimate
                 om_r = xh(1,1)
-                v_h = xh(2,1)
-                ! v_m = xh(3,1)
-                ! v_h = v_t + v_m
-                ! LocalVar%WE_Vw = v_m + v_t
-                LocalVar%WE_Vw = V_h
+                v_t = xh(2,1)
+                v_m = xh(3,1)
+                v_h = v_t + v_m
+                LocalVar%WE_Vw = v_m + v_t
 
             ENDIF
             ! Debug Outputs

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -193,7 +193,7 @@ CONTAINS
         LocalVar%VS_LastGenTrq = LocalVar%GenTq
         
         ! Set the command generator torque (See Appendix A of Bladed User's Guide):
-        avrSWAP(47) = MAX(0.0+epsilon(0.0), LocalVar%VS_LastGenTrq)  ! Demanded generator torque, prevent negatives.
+        avrSWAP(47) = MAX(0.0, LocalVar%VS_LastGenTrq)  ! Demanded generator torque, prevent negatives.
     END SUBROUTINE VariableSpeedControl
 !-------------------------------------------------------------------------------------------------------------------------------
     SUBROUTINE YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -193,7 +193,7 @@ CONTAINS
         LocalVar%VS_LastGenTrq = LocalVar%GenTq
         
         ! Set the command generator torque (See Appendix A of Bladed User's Guide):
-        avrSWAP(47) = LocalVar%VS_LastGenTrq   ! Demanded generator torque
+        avrSWAP(47) = MAX(0.0+epsilon(0.0), LocalVar%VS_LastGenTrq)  ! Demanded generator torque, prevent negatives.
     END SUBROUTINE VariableSpeedControl
 !-------------------------------------------------------------------------------------------------------------------------------
     SUBROUTINE YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -244,20 +244,7 @@ CONTAINS
             ! Update commanded offset if needed
             IF (ALLOCATED(CntrPar%Y_MErrHist)) THEN
                 ! Interpolate
-                Time = avrSWAP(2)
-                DO WHILE ((Tidx < SIZE(CntrPar%Y_MErrHist)-1) .and. &
-                          (Time .gt. CntrPar%Y_MErrTime(Tidx+1)))
-                    Tidx = Tidx + 1
-                END DO
-                CntrPar%Y_MErrSet = CntrPar%Y_MErrHist(Tidx) &
-                        + (CntrPar%Y_MErrHist(Tidx+1)-CntrPar%Y_MErrHist(Tidx)) / &
-                          (CntrPar%Y_MErrTime(Tidx+1)-CntrPar%Y_MErrTime(Tidx)) * &
-                          (Time - CntrPar%Y_MErrTime(Tidx))
-                !WRITE(*,'(a,f10.4,a,a,f10.4,a,f10.4)') &
-                !        't=',Time,' : ', &
-                !        'interp btwn',CntrPar%Y_MErrTime(Tidx), &
-                !        ', ',CntrPar%Y_MErrTime(Tidx+1), &
-                !        ' = ',CntrPar%Y_MErrSet
+                CntrPar%Y_MErrSet = interp1d(CntrPar%Y_MErrTime, CntrPar%Y_MErrHist, LocalVar%Time)
             END IF
 
             ! Compute/apply offset

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -223,6 +223,8 @@ CONTAINS
         REAL(8), SAVE :: Y_Err                                  ! Yaw error (deg)
         REAL(8)       :: YawRateCom                             ! Commanded yaw rate
         REAL(8)       :: deadband                               ! Allowable yaw error deadband (rad)
+        REAL(8)       :: Time                                   ! Current time
+        INTEGER, SAVE :: TimeIndex                              ! Index i: commanded yaw error is interpolated between i and i+1
         
         IF (CntrPar%Y_ControlMode == 1) THEN
 
@@ -233,11 +235,24 @@ CONTAINS
             IF (LocalVar%iStatus == 0) THEN
                 Yaw = LocalVar%Nac_YawNorth
                 YawState = 0
+                TimeIndex = 0
             ENDIF
             
             ! Compute wind vane
             NacVane = wrap_180(WindDir - Yaw)      ! Measured yaw error 
             
+            ! Update commanded offset if needed
+            Time = avrSWAP(2)
+            !IF (SIZE(CntrPar%Y_MErrSet) > 1) THEN
+            !    ! Interpolate
+            !    Time = avrSWAP(2)
+            !    DO WHILE (TimeIndex < SIZE(CntrPar%Y_MErrSet)) .and. &
+            !             ((Time .lt. YawHistTime(TimeIndex) &
+            !              .or. (Time .ge. YawHistTime(TimeIndex+1))
+            !        TimeIndex = TimeIndex + 1
+            !    END DO
+            !END IF
+
             ! Compute/apply offset
             NacVaneOffset = NacVane - CntrPar%Y_MErrSet ! (deg)
             

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -249,9 +249,8 @@ CONTAINS
 
             ! Compute/apply offset
             NacVaneOffset = NacVane - CntrPar%Y_MErrSet ! (deg)
-            
             ! Update filtered wind direction
-            WindDir_n = wrap_360(WindDir - CntrPar%Y_MErrSet) ! (deg)
+            WindDir_n = wrap_360(NacVane - NacVaneOffset) ! (deg)
             WindDirCosF = LPFilter(cos(WindDir_n*D2R), LocalVar%DT, CntrPar%F_YawErr, LocalVar%iStatus, .FALSE., objInst%instLPF) ! (-)
             WindDirSinF = LPFilter(sin(WindDir_n*D2R), LocalVar%DT, CntrPar%F_YawErr, LocalVar%iStatus, .FALSE., objInst%instLPF) ! (-)
             WindDirF = wrap_360(atan2(WindDirSinF, WindDirCosF) * R2D) ! (deg)

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -306,16 +306,18 @@ CONTAINS
             ENDIF
 
             ! Output yaw rate command
-            avrSWAP(48) = YawRateCom       
+            avrSWAP(48)      = YawRateCom       
             LocalVar%Y_Angle = Yaw
 
             ! Save for debug
-            DebugVar%YawRateCom = YawRateCom
-            DebugVar%WindDir = WindDir
-            DebugVar%WindDirF = WindDirF
-            DebugVar%NacVane = NacVane
-            DebugVar%NacVaneOffset = NacVaneOffset
-            DebugVar%Yaw_err = Y_Err
+            DebugVar%YawRateCom     = YawRateCom
+            DebugVar%WindDir        = WindDir
+            DebugVar%WindDir_n      = WindDir_n
+            DebugVar%WindDirF       = WindDirF
+            DebugVar%NacVane        = NacVane
+            DebugVar%NacVaneOffset  = NacVaneOffset
+            DebugVar%Yaw_err        = Y_Err
+            DebugVar%YawState       = YawState
 
         END IF
     END SUBROUTINE YawRateControl

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -240,21 +240,22 @@ CONTAINS
             
             ! Compute wind vane
             NacVane = wrap_180(WindDir - Yaw)      ! Measured yaw error 
-            
+
             ! Update commanded offset if needed
             IF (ALLOCATED(CntrPar%Y_MErrHist)) THEN
                 ! Interpolate
                 CntrPar%Y_MErrSet = interp1d(CntrPar%Y_MErrTime, CntrPar%Y_MErrHist, LocalVar%Time)
             END IF
-
+            
             ! Compute/apply offset
-            NacVaneOffset = NacVane - CntrPar%Y_MErrSet ! (deg)
+            NacVaneOffset = CntrPar%Y_MErrSet ! (deg) # Offset from setpoint
+
             ! Update filtered wind direction
-            WindDir_n = wrap_360(NacVane - NacVaneOffset) ! (deg)
+            WindDir_n = wrap_360(WindDir - NacVaneOffset) ! (deg)
             WindDirCosF = LPFilter(cos(WindDir_n*D2R), LocalVar%DT, CntrPar%F_YawErr, LocalVar%iStatus, .FALSE., objInst%instLPF) ! (-)
             WindDirSinF = LPFilter(sin(WindDir_n*D2R), LocalVar%DT, CntrPar%F_YawErr, LocalVar%iStatus, .FALSE., objInst%instLPF) ! (-)
             WindDirF = wrap_360(atan2(WindDirSinF, WindDirCosF) * R2D) ! (deg)
-
+            
             ! ---- Now get into the guts of the control ----
             ! Yaw error
             Y_Err = wrap_180(WindDirF - Yaw)

--- a/src/Controllers.f90
+++ b/src/Controllers.f90
@@ -196,7 +196,7 @@ CONTAINS
         avrSWAP(47) = LocalVar%VS_LastGenTrq   ! Demanded generator torque
     END SUBROUTINE VariableSpeedControl
 !-------------------------------------------------------------------------------------------------------------------------------
-    SUBROUTINE YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)
+    SUBROUTINE YawRateControl(avrSWAP, CntrPar, LocalVar, objInst, DebugVar)
         ! Yaw rate controller
         !       Y_ControlMode = 0, No yaw control
         !       Y_ControlMode = 1, Yaw rate control using yaw drive
@@ -204,13 +204,14 @@ CONTAINS
 
         ! TODO: Lots of R2D->D2R, this should be cleaned up.
         ! TODO: The constant offset implementation is sort of circular here as a setpoint is already being defined in SetVariablesSetpoints. This could also use cleanup
-        USE ROSCO_Types, ONLY : ControlParameters, LocalVariables, ObjectInstances
+        USE ROSCO_Types, ONLY : ControlParameters, LocalVariables, ObjectInstances, DebugVariables
     
         REAL(C_FLOAT), INTENT(INOUT) :: avrSWAP(*) ! The swap array, used to pass data to, and receive data from, the DLL controller.
     
         TYPE(ControlParameters), INTENT(INOUT)    :: CntrPar
         TYPE(LocalVariables), INTENT(INOUT)       :: LocalVar
         TYPE(ObjectInstances), INTENT(INOUT)      :: objInst
+        TYPE(DebugVariables), INTENT(INOUT)       :: DebugVar
         
         ! Allocate Variables
         REAL(8), SAVE :: Yaw                                    ! Current yaw command--separate from YawPos--that dictates the commanded yaw position and should stay fixed for YawState==0; if the input YawPos is used, then it effectively allows the nacelle to freely rotate rotate
@@ -309,10 +310,12 @@ CONTAINS
             LocalVar%Y_Angle = Yaw
 
             ! Save for debug
-            LocalVar%YawRateCom = YawRateCom
-            LocalVar%WindDir = WindDir
-            LocalVar%NacVane = NacVane
-            LocalVar%Yaw_err = Y_Err
+            DebugVar%YawRateCom = YawRateCom
+            DebugVar%WindDir = WindDir
+            DebugVar%WindDirF = WindDirF
+            DebugVar%NacVane = NacVane
+            DebugVar%NacVaneOffset = NacVaneOffset
+            DebugVar%Yaw_err = Y_Err
 
         END IF
     END SUBROUTINE YawRateControl

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -65,17 +65,15 @@ CALL SetParameters(avrSWAP, aviFAIL, accINFILE, ErrMsg, SIZE(avcMSG), CntrPar, L
 CALL PreFilterMeasuredSignals(CntrPar, LocalVar, objInst)
 
 IF ((LocalVar%iStatus >= 0) .AND. (aviFAIL >= 0))  THEN  ! Only compute control calculations if no error has occurred and we are not on the last time step
-    CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
-    
-    CALL StateMachine(CntrPar, LocalVar)
     CALL WindSpeedEstimator(LocalVar, CntrPar, objInst, PerfData, DebugVar)
+    CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
+    CALL StateMachine(CntrPar, LocalVar)
     CALL SetpointSmoother(LocalVar, CntrPar, objInst)
     CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
     CALL VariableSpeedControl(avrSWAP, CntrPar, LocalVar, objInst)
     CALL PitchControl(avrSWAP, CntrPar, LocalVar, objInst, DebugVar)
     CALL YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)
     CALL FlapControl(avrSWAP, CntrPar, LocalVar, objInst)
-    
     CALL Debug(LocalVar, CntrPar, DebugVar, avrSWAP, RootName, SIZE(avcOUTNAME))
 END IF
 

--- a/src/DISCON.F90
+++ b/src/DISCON.F90
@@ -71,7 +71,7 @@ IF ((LocalVar%iStatus >= 0) .AND. (aviFAIL >= 0))  THEN  ! Only compute control 
     CALL ComputeVariablesSetpoints(CntrPar, LocalVar, objInst)
     CALL VariableSpeedControl(avrSWAP, CntrPar, LocalVar, objInst)
     CALL PitchControl(avrSWAP, CntrPar, LocalVar, objInst, DebugVar)
-    CALL YawRateControl(avrSWAP, CntrPar, LocalVar, objInst)
+    CALL YawRateControl(avrSWAP, CntrPar, LocalVar, objInst, DebugVar)
     CALL FlapControl(avrSWAP, CntrPar, LocalVar, objInst)
     
     CALL Debug(LocalVar, CntrPar, DebugVar, avrSWAP, RootName, SIZE(avcOUTNAME))

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -291,7 +291,7 @@ CONTAINS
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
         ! Filter Wind Speed Estimator Signal
-        LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, LocalVar%iStatus,.FALSE.,objInst%instLPF) ! 30 second time constant
 
 
         ! Control commands (used by WSE, mostly)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -292,9 +292,9 @@ CONTAINS
         
         ! Filter Wind Speed Estimator Signal
         IF (CntrPar%F_LPFType == 1) THEN
-            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.2094, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ELSE
-            LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+            LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ENDIF 
 
         ! Control commands (used by WSE, mostly)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -290,8 +290,12 @@ CONTAINS
 
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
-        ! Wind Speed Estimator
-        LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw,LocalVar%DT,0.21D0,0.7D0,LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ! Filter Wind Speed Estimator Signal
+        IF (CntrPar%F_LPFType == 1) THEN
+            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ELSE
+            LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+        ENDIF 
 
         ! Control commands (used by WSE, mostly)
         LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7D0, LocalVar%iStatus, .FALSE., objInst%instSecLPF)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -291,11 +291,8 @@ CONTAINS
         LocalVar%FA_AccHPF = HPFilter(LocalVar%FA_Acc, LocalVar%DT, CntrPar%FA_HPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instHPF)
         
         ! Filter Wind Speed Estimator Signal
-        IF (CntrPar%F_LPFType == 1) THEN
-            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
-        ELSE
-            LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
-        ENDIF 
+        LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.209, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+
 
         ! Control commands (used by WSE, mostly)
         LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7, LocalVar%iStatus, .FALSE., objInst%instSecLPF)

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -276,11 +276,11 @@ CONTAINS
         IF (CntrPar%Fl_Mode == 1) THEN
             ! Force to start at 0
             IF (LocalVar%iStatus == 0) THEN
-                LocalVar%NacIMU_FA_AccF = SecLPFilter(0.D0, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
+                LocalVar%NacIMU_FA_AccF = SecLPFilter(0., LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
             ELSE
                 LocalVar%NacIMU_FA_AccF = SecLPFilter(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instSecLPF) ! Fixed Damping
             ENDIF
-            LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, 0.0167D0, LocalVar%iStatus, .FALSE., objInst%instHPF) 
+            LocalVar%NacIMU_FA_AccF = HPFilter(LocalVar%NacIMU_FA_AccF, LocalVar%DT, 0.0167, LocalVar%iStatus, .FALSE., objInst%instHPF) 
             ! LocalVar%NacIMU_FA_AccF = NotchFilterSlopes(LocalVar%NacIMU_FA_Acc, LocalVar%DT, CntrPar%F_FlCornerFreq, CntrPar%F_FlDamping, LocalVar%iStatus, .FALSE., objInst%instNotchSlopes) ! Fixed Damping
             
             IF (CntrPar%F_NotchType >= 2) THEN
@@ -292,13 +292,13 @@ CONTAINS
         
         ! Filter Wind Speed Estimator Signal
         IF (CntrPar%F_LPFType == 1) THEN
-            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.2094D0, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.2094, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ELSE
             LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ENDIF 
 
         ! Control commands (used by WSE, mostly)
-        LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7D0, LocalVar%iStatus, .FALSE., objInst%instSecLPF)
+        LocalVar%VS_LastGenTrqF = SecLPFilter(LocalVar%VS_LastGenTrq, LocalVar%dt, CntrPar%F_LPFCornerFreq, 0.7, LocalVar%iStatus, .FALSE., objInst%instSecLPF)
         LocalVar%PC_PitComTF = LPFilter(LocalVar%PC_PitComT, LocalVar%dt, CntrPar%F_LPFCornerFreq, LocalVar%iStatus, .FALSE., objInst%instLPF)
 
     END SUBROUTINE PreFilterMeasuredSignals

--- a/src/Filters.f90
+++ b/src/Filters.f90
@@ -292,7 +292,7 @@ CONTAINS
         
         ! Filter Wind Speed Estimator Signal
         IF (CntrPar%F_LPFType == 1) THEN
-            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
+            LocalVar%We_Vw_F = LPFilter(LocalVar%WE_Vw, LocalVar%DT, 0.2094D0, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ELSE
             LocalVar%We_Vw_F = SecLPFilter(LocalVar%WE_Vw, LocalVar%DT, CntrPar%F_LPFCornerFreq, CntrPar%F_LPFDamping, LocalVar%iStatus,.FALSE.,objInst%instSecLPF) ! 30 second time constant
         ENDIF 

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -409,7 +409,7 @@ CONTAINS
         
         ! Lookup
         CPfunction = exp(-CP(1)/lambda)*(CP(2)/lambda-CP(3))+CP(4)*lambda
-        CPfunction = saturate(CPfunction, 0.001, 1.0)
+        CPfunction = saturate(CPfunction, 0.001D0, 1.0D0)
         
     END FUNCTION CPfunction
 !-------------------------------------------------------------------------------------------------------------------------------

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -473,7 +473,7 @@ CONTAINS
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 20
+        nDebugOuts = 18
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         ! Filters
@@ -495,10 +495,8 @@ CONTAINS
         DebugOutStr14  = 'WE_w';         DebugOutUni14  = '(rad/s)';   DebugOutData(14)  = DebugVar%WE_w
         DebugOutStr15  = 'WE_Vm';        DebugOutUni15  = '(m/s)';     DebugOutData(15)  = DebugVar%WE_Vm
         DebugOutStr16  = 'WE_Vt';        DebugOutUni16  = '(m/s)';     DebugOutData(16)  = DebugVar%WE_Vt
-        DebugOutStr17  = 'WE_Cp';        DebugOutUni17  = '(-)';       DebugOutData(17)  = DebugVar%WE_Cp
-        DebugOutStr18  = 'WE_lambda';    DebugOutUni18  = '(rad/s)';   DebugOutData(18)  = DebugVar%WE_lambda
-        DebugOutStr19  = 'WE_F12';       DebugOutUni19  = '(-)';       DebugOutData(19)  = DebugVar%WE_F12
-        DebugOutStr20  = 'WE_F13';       DebugOutUni20  = '(-)';       DebugOutData(20)  = DebugVar%WE_F13
+        DebugOutStr17  = 'WE_lambda';    DebugOutUni17  = '(rad/s)';   DebugOutData(17)  = DebugVar%WE_lambda
+        DebugOutStr18  = 'WE_Cp';        DebugOutUni18  = '(-)';       DebugOutData(18)  = DebugVar%WE_Cp
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
@@ -506,12 +504,12 @@ CONTAINS
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
                                                 DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12, &
                                                 DebugOutStr13, DebugOutStr14, DebugOutStr15, DebugOutStr16, &
-                                                DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20]
+                                                DebugOutStr17, DebugOutStr18]
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
                                                 DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12, &
                                                 DebugOutUni13, DebugOutUni14, DebugOutUni15, DebugOutUni1, &
-                                                DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20]
+                                                DebugOutUni17, DebugOutUni18]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL
@@ -523,7 +521,7 @@ CONTAINS
                 WRITE (UnDb,'(99(a10,TR5:))') '(sec)',  DebugOutUnits
             END IF
             
-            IF (CntrPar%LoggingLevel > 1) THEN
+            IF (CntrPar%LoggingLevel > 1) THEN 
                 OPEN(unit=UnDb2, FILE='DEBUG2.dbg')
                 WRITE(UnDb2,'(/////)')
                 WRITE(UnDb2,'(A,85("'//Tab//'AvrSWAP(",I2,")"))')  'LocalVar%Time ', (i,i=1,85)

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -493,24 +493,24 @@ CONTAINS
                                                          DebugOutStr11, DebugOutStr12, DebugOutStr13, DebugOutStr14, DebugOutStr15, & 
                                                          DebugOutStr16, DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20, &    
                                                          DebugOutStr21, DebugOutStr22, DebugOutStr23, DebugOutStr24, DebugOutStr25, &
-                                                         DebugOutStr26                                                       
+                                                         DebugOutStr26, DebugOutStr27, DebugOutStr28, DebugOutStr29, DebugOutStr30                                                        
         CHARACTER(10)                               :: DebugOutUni1,  DebugOutUni2, DebugOutUni3, DebugOutUni4, DebugOutUni5, &
                                                          DebugOutUni6, DebugOutUni7, DebugOutUni8, DebugOutUni9, DebugOutUni10, &
                                                          DebugOutUni11, DebugOutUni12, DebugOutUni13, DebugOutUni14, DebugOutUni15, & 
                                                          DebugOutUni16, DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20, &
                                                          DebugOutUni21, DebugOutUni22, DebugOutUni23, DebugOutUni24, DebugOutUni25, & 
-                                                         DebugOutUni26
+                                                         DebugOutUni26, DebugOutUni27, DebugOutUni28, DebugOutUni29, DebugOutUni30
         CHARACTER(10), ALLOCATABLE                  :: DebugOutStrings(:), DebugOutUnits(:)
         REAL(8), ALLOCATABLE                        :: DebugOutData(:)
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 26
+        nDebugOuts = 30
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         ! Filters
-        DebugOutStr1   = 'FA_AccF';     DebugOutUni1   = '(m/s)';      DebugOutData(1)   = LocalVar%NacIMU_FA_AccF
-        DebugOutStr2   = 'FA_AccR';     DebugOutUni2   = '(rad/s^2)';  DebugOutData(2)   = LocalVar%NacIMU_FA_Acc
+        DebugOutStr1  = 'FA_AccF';      DebugOutUni1  = '(m/s)';       DebugOutData(1)  = LocalVar%NacIMU_FA_AccF
+        DebugOutStr2  = 'FA_AccR';      DebugOutUni2  = '(rad/s^2)';   DebugOutData(2)  = LocalVar%NacIMU_FA_Acc
         DebugOutStr3  = 'RotSpeed';     DebugOutUni3  = '(rad/s)';     DebugOutData(3)  = LocalVar%RotSpeed
         DebugOutStr4  = 'RotSpeedF';    DebugOutUni4  = '(rad/s)';     DebugOutData(4)  = LocalVar%RotSpeedF
         DebugOutStr5  = 'GenSpeed';     DebugOutUni5  = '(rad/s)';     DebugOutData(5)  = LocalVar%GenSpeed
@@ -532,12 +532,16 @@ CONTAINS
         DebugOutStr19  = 'WE_F12';       DebugOutUni19  = '(-)';       DebugOutData(19)  = DebugVar%WE_F12
         DebugOutStr20  = 'WE_F13';       DebugOutUni20  = '(-)';       DebugOutData(20)  = DebugVar%WE_F13
         ! Yaw
-        DebugOutStr21   = 'YawRateCom';    DebugOutUni21 = '(-)';      DebugOutData(21)   = DebugVar%YawRateCom
-        DebugOutStr22   = 'WindDir';       DebugOutUni22 = '(-)';      DebugOutData(22)   = DebugVar%WindDir
-        DebugOutStr23   = 'WindDirF';      DebugOutUni23 = '(-)';      DebugOutData(23)   = DebugVar%WindDirF
-        DebugOutStr24   = 'NacVane';       DebugOutUni24 = '(-)';      DebugOutData(24)   = DebugVar%NacVane
-        DebugOutStr25   = 'NacVaneOffset'; DebugOutUni25 = '(-)';      DebugOutData(25)   = DebugVar%NacVaneOffset
-        DebugOutStr26   = 'Yaw_err';       DebugOutUni26 = '(-)';      DebugOutData(26)   = DebugVar%Yaw_err
+        DebugOutStr21   = 'YawRateCom';    DebugOutUni21 = '(deg)';      DebugOutData(21)  = DebugVar%YawRateCom
+        DebugOutStr22   = 'WindDir';       DebugOutUni22 = '(deg)';      DebugOutData(22)  = DebugVar%WindDir
+        DebugOutStr23   = 'WindDir_n';     DebugOutUni23 = '(deg)';      DebugOutData(23)  = DebugVar%WindDir_n
+        DebugOutStr24   = 'WindDirF';      DebugOutUni24 = '(deg)';      DebugOutData(24)  = DebugVar%WindDirF
+        DebugOutStr25   = 'NacVane';       DebugOutUni25 = '(deg)';      DebugOutData(25)  = DebugVar%NacVane
+        DebugOutStr26   = 'NacVaneOffset'; DebugOutUni26 = '(deg)';      DebugOutData(26)  = DebugVar%NacVaneOffset
+        DebugOutStr27   = 'Yaw_err';       DebugOutUni27 = '(deg)';      DebugOutData(27)  = DebugVar%Yaw_err
+        DebugOutStr28   = 'Nac_YawNorth';  DebugOutUni28 = '(deg)';      DebugOutData(28)  = LocalVar%Nac_YawNorth
+        DebugOutStr29   = 'Y_Angle';       DebugOutUni29 = '(deg)';      DebugOutData(29)  = LocalVar%Y_Angle
+        DebugOutStr30   = 'YawState';      DebugOutUni30 = '(deg)';      DebugOutData(30)  = DebugVar%YawState
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
@@ -547,7 +551,8 @@ CONTAINS
                                                 DebugOutStr13, DebugOutStr14, DebugOutStr15, DebugOutStr16, &
                                                 DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20, &
                                                 DebugOutStr21, DebugOutStr22, DebugOutStr23, DebugOutStr24, &
-                                                DebugOutStr25, DebugOutStr26]
+                                                DebugOutStr25, DebugOutStr26, DebugOutStr27, DebugOutStr28, &
+                                                DebugOutStr29, DebugOutStr30]
 
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
@@ -555,7 +560,8 @@ CONTAINS
                                                 DebugOutUni13, DebugOutUni14, DebugOutUni15, DebugOutUni1, &
                                                 DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20, &
                                                 DebugOutUni21, DebugOutUni22, DebugOutUni23, DebugOutUni24, &
-                                                DebugOutUni25, DebugOutUni26]
+                                                DebugOutUni25, DebugOutUni26, DebugOutUni27, DebugOutUni28, &
+                                                DebugOutUni29, DebugOutUni30]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -491,17 +491,21 @@ CONTAINS
         CHARACTER(10)                               :: DebugOutStr1,  DebugOutStr2, DebugOutStr3, DebugOutStr4, DebugOutStr5, &
                                                          DebugOutStr6, DebugOutStr7, DebugOutStr8, DebugOutStr9, DebugOutStr10, &
                                                          DebugOutStr11, DebugOutStr12, DebugOutStr13, DebugOutStr14, DebugOutStr15, & 
-                                                         DebugOutStr16, DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20                                                           
+                                                         DebugOutStr16, DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20, &    
+                                                         DebugOutStr21, DebugOutStr22, DebugOutStr23, DebugOutStr24, DebugOutStr25, &
+                                                         DebugOutStr26                                                       
         CHARACTER(10)                               :: DebugOutUni1,  DebugOutUni2, DebugOutUni3, DebugOutUni4, DebugOutUni5, &
                                                          DebugOutUni6, DebugOutUni7, DebugOutUni8, DebugOutUni9, DebugOutUni10, &
                                                          DebugOutUni11, DebugOutUni12, DebugOutUni13, DebugOutUni14, DebugOutUni15, & 
-                                                         DebugOutUni16, DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20 
+                                                         DebugOutUni16, DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20, &
+                                                         DebugOutUni21, DebugOutUni22, DebugOutUni23, DebugOutUni24, DebugOutUni25, & 
+                                                         DebugOutUni26
         CHARACTER(10), ALLOCATABLE                  :: DebugOutStrings(:), DebugOutUnits(:)
         REAL(8), ALLOCATABLE                        :: DebugOutData(:)
 
         ! Set up Debug Strings and Data
         ! Note that Debug strings have 10 character limit
-        nDebugOuts = 20
+        nDebugOuts = 26
         ALLOCATE(DebugOutData(nDebugOuts))
         !                 Header                            Unit                                Variable
         ! Filters
@@ -527,6 +531,12 @@ CONTAINS
         DebugOutStr18  = 'WE_lambda';    DebugOutUni18  = '(rad/s)';   DebugOutData(18)  = DebugVar%WE_lambda
         DebugOutStr19  = 'WE_F12';       DebugOutUni19  = '(-)';       DebugOutData(19)  = DebugVar%WE_F12
         DebugOutStr20  = 'WE_F13';       DebugOutUni20  = '(-)';       DebugOutData(20)  = DebugVar%WE_F13
+        DebugOutStr21   = 'YawRateCom';    DebugOutUni21 = '(-)';      DebugOutData(21)   = DebugVar%YawRateCom
+        DebugOutStr22   = 'WindDir';       DebugOutUni22 = '(-)';      DebugOutData(22)   = DebugVar%WindDir
+        DebugOutStr23   = 'WindDirF';      DebugOutUni23 = '(-)';      DebugOutData(23)   = DebugVar%WindDirF
+        DebugOutStr24   = 'NacVane';       DebugOutUni24 = '(-)';      DebugOutData(24)   = DebugVar%NacVane
+        DebugOutStr25   = 'NacVaneOffset'; DebugOutUni25 = '(-)';      DebugOutData(25)   = DebugVar%NacVaneOffset
+        DebugOutStr26   = 'Yaw_err';       DebugOutUni26 = '(-)';      DebugOutData(26)   = DebugVar%Yaw_err
 
         Allocate(DebugOutStrings(nDebugOuts))
         Allocate(DebugOutUnits(nDebugOuts))
@@ -534,12 +544,17 @@ CONTAINS
                                                 DebugOutStr5, DebugOutStr6, DebugOutStr7, DebugOutStr8, &
                                                 DebugOutStr9, DebugOutStr10, DebugOutStr11, DebugOutStr12, &
                                                 DebugOutStr13, DebugOutStr14, DebugOutStr15, DebugOutStr16, &
-                                                DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20]
+                                                DebugOutStr17, DebugOutStr18, DebugOutStr19, DebugOutStr20, &
+                                                DebugOutStr21, DebugOutStr22, DebugOutStr23, DebugOutStr24, &
+                                                DebugOutStr25, DebugOutStr26]
+
         DebugOutUnits =     [CHARACTER(10)  :: DebugOutUni1, DebugOutUni2, DebugOutUni3, DebugOutUni4, &
                                                 DebugOutUni5, DebugOutUni6, DebugOutUni7, DebugOutUni8, &
                                                 DebugOutUni9, DebugOutUni10, DebugOutUni11, DebugOutUni12, &
                                                 DebugOutUni13, DebugOutUni14, DebugOutUni15, DebugOutUni1, &
-                                                DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20]
+                                                DebugOutUni17, DebugOutUni18, DebugOutUni19, DebugOutUni20, &
+                                                DebugOutUni21, DebugOutUni22, DebugOutUni23, DebugOutUni24, &
+                                                DebugOutUni25, DebugOutUni26]
         
         ! Initialize debug file
         IF (LocalVar%iStatus == 0)  THEN  ! .TRUE. if we're on the first call to the DLL

--- a/src/Functions.f90
+++ b/src/Functions.f90
@@ -531,6 +531,7 @@ CONTAINS
         DebugOutStr18  = 'WE_lambda';    DebugOutUni18  = '(rad/s)';   DebugOutData(18)  = DebugVar%WE_lambda
         DebugOutStr19  = 'WE_F12';       DebugOutUni19  = '(-)';       DebugOutData(19)  = DebugVar%WE_F12
         DebugOutStr20  = 'WE_F13';       DebugOutUni20  = '(-)';       DebugOutData(20)  = DebugVar%WE_F13
+        ! Yaw
         DebugOutStr21   = 'YawRateCom';    DebugOutUni21 = '(-)';      DebugOutData(21)   = DebugVar%YawRateCom
         DebugOutStr22   = 'WindDir';       DebugOutUni22 = '(-)';      DebugOutData(22)   = DebugVar%WindDir
         DebugOutStr23   = 'WindDirF';      DebugOutUni23 = '(-)';      DebugOutData(23)   = DebugVar%WindDirF

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -216,16 +216,15 @@ TYPE, PUBLIC :: PerformanceData
     REAL(8), DIMENSION(:,:), ALLOCATABLE    :: Cq_mat
 END TYPE PerformanceData
 
-TYPE, PUBLIC :: DebugVariables
-    REAL(8)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_b                         ! Pitch that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_w                         ! Rotor Speed that WSE uses to determine aerodynamic torque, for debug purposes [-]
-    REAL(8)                             :: WE_t                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_Vm                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_Vt                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_lambda                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_F12                         ! Torque that WSE uses, for debug purposes [-]
-    REAL(8)                             :: WE_F13                         ! Torque that WSE uses, for debug purposes [-]
+TYPE, PUBLIC :: DebugVariables                                          
+! Variables used for debug purposes
+    REAL(8)                             :: WE_Cp                        ! Cp that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_b                         ! Pitch that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_w                         ! Rotor Speed that WSE uses to determine aerodynamic torque[-]
+    REAL(8)                             :: WE_t                         ! Torque that WSE uses[-]
+    REAL(8)                             :: WE_Vm                        ! Mean wind speed component in WSE [m/s]
+    REAL(8)                             :: WE_Vt                        ! Turbulent wind speed component in WSE [m/s]
+    REAL(8)                             :: WE_lambda                    ! TSR in WSE [rad]
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -242,10 +242,12 @@ TYPE, PUBLIC :: DebugVariables
     REAL(8)                             :: WE_F13                         ! Torque that WSE uses, for debug purposes [-]
     REAL(8)                             :: YawRateCom
     REAL(8)                             :: WindDir
+    REAL(8)                             :: WindDir_n
     REAL(8)                             :: WindDirF
     REAL(8)                             :: NacVane
     REAL(8)                             :: NacVaneOffset
     REAL(8)                             :: Yaw_err
+    REAL(8)                             :: YawState
 
 END TYPE DebugVariables
 

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -101,6 +101,8 @@ TYPE, PUBLIC :: ControlParameters
     REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_ErrThresh                  ! Error threshold [rad]. Turbine begins to yaw when it passes this. (104.71975512) -- 1.745329252
     REAL(8)                             :: Y_Rate                       ! Yaw rate [rad/s]
     REAL(8)                             :: Y_MErrSet                    ! Yaw measurement error offset (for wake steering) [rad]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_MErrHist                   ! History of desired yaw offsets [rad]
+    REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_MErrTime                   ! Times corresponding to history of desired yaw offsets
     REAL(8)                             :: Y_IPC_IntSat                 ! Integrator saturation (maximum signal amplitude contrbution to pitch from yaw-by-IPC)
     INTEGER(4)                          :: Y_IPC_n                      ! Number of controller gains (yaw-by-IPC)
     REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_IPC_KP                     ! Yaw-by-IPC proportional controller gain Kp

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -240,6 +240,13 @@ TYPE, PUBLIC :: DebugVariables
     REAL(8)                             :: WE_lambda                         ! Torque that WSE uses, for debug purposes [-]
     REAL(8)                             :: WE_F12                         ! Torque that WSE uses, for debug purposes [-]
     REAL(8)                             :: WE_F13                         ! Torque that WSE uses, for debug purposes [-]
+    REAL(8)                             :: YawRateCom
+    REAL(8)                             :: WindDir
+    REAL(8)                             :: WindDirF
+    REAL(8)                             :: NacVane
+    REAL(8)                             :: NacVaneOffset
+    REAL(8)                             :: Yaw_err
+
 END TYPE DebugVariables
 
 END MODULE ROSCO_Types

--- a/src/ROSCO_Types.f90
+++ b/src/ROSCO_Types.f90
@@ -100,7 +100,7 @@ TYPE, PUBLIC :: ControlParameters
     REAL(8)                             :: Y_uSwitch                    ! Wind speed to switch between Y_ErrThresh. If zero, only the first value of Y_ErrThresh is used [rad]
     REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_ErrThresh                  ! Error threshold [rad]. Turbine begins to yaw when it passes this. (104.71975512) -- 1.745329252
     REAL(8)                             :: Y_Rate                       ! Yaw rate [rad/s]
-    REAL(8)                             :: Y_MErrSet                    ! Constant yaw measurement error offset (for wake stearing) [rad]
+    REAL(8)                             :: Y_MErrSet                    ! Yaw measurement error offset (for wake steering) [rad]
     REAL(8)                             :: Y_IPC_IntSat                 ! Integrator saturation (maximum signal amplitude contrbution to pitch from yaw-by-IPC)
     INTEGER(4)                          :: Y_IPC_n                      ! Number of controller gains (yaw-by-IPC)
     REAL(8), DIMENSION(:), ALLOCATABLE  :: Y_IPC_KP                     ! Yaw-by-IPC proportional controller gain Kp

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -548,8 +548,6 @@ CONTAINS
                      'https://github.com/NREL/ROSCO                                                 '//NEW_LINE('A')// &
                      '------------------------------------------------------------------------------'
 
-                ! print *, 'Version 1.0.1: pretty debug'
-
             CALL ReadControlParameterFileSub(CntrPar, accINFILE, NINT(avrSWAP(50)))
 
             IF (CntrPar%WE_Mode > 0) THEN
@@ -559,11 +557,7 @@ CONTAINS
             LocalVar%TestType = 0
         
             ! Initialize the SAVED variables:
-
-            ! DO K = 1,LocalVar%NumBl
             LocalVar%PitCom = LocalVar%BlPitch ! This will ensure that the variable speed controller picks the correct control region and the pitch controller picks the correct gain on the first call
-            ! END DO
-            
             LocalVar%Y_AccErr = 0.0  ! This will ensure that the accumulated yaw error starts at zero
             LocalVar%Y_YawEndT = -1.0 ! This will ensure that the initial yaw end time is lower than the actual time to prevent initial yawing
             

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -567,8 +567,8 @@ CONTAINS
             LocalVar%Y_AccErr = 0.0  ! This will ensure that the accumulated yaw error starts at zero
             LocalVar%Y_YawEndT = -1.0 ! This will ensure that the initial yaw end time is lower than the actual time to prevent initial yawing
             
-            ! Wind speed estimator initialization, we always assume an initial wind speed of 10 m/s
-            LocalVar%WE_Vw = 10
+            ! Wind speed estimator initialization
+            LocalVar%WE_Vw = LocalVar%HorWindV
             LocalVar%WE_VwI = LocalVar%WE_Vw - CntrPar%WE_Gamma*LocalVar%RotSpeed
             
             ! Setpoint Smoother initialization to zero

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -684,6 +684,7 @@ CONTAINS
         TYPE(ControlParameters), INTENT(INOUT) :: CntrPar
         ! Local variables
         INTEGER :: i, istat, Ntimes
+        REAL(8) :: dummy
 
         WRITE(*,*) 'Reading commanded yaw offsets from '//TRIM(FileName)
         ! First pass: get number of times
@@ -692,7 +693,7 @@ CONTAINS
         OPEN(unit=YawOffsetHist, file=TRIM(FileName), status='old', action='read') 
         DO WHILE (istat == 0)
             Ntimes = Ntimes + 1
-            READ(YawOffsetHist, *, iostat=istat)
+            READ(YawOffsetHist, *, iostat=istat) dummy, dummy
         END DO
 
         ALLOCATE(CntrPar%Y_MErrTime(Ntimes))

--- a/src/ReadSetParameters.f90
+++ b/src/ReadSetParameters.f90
@@ -40,6 +40,7 @@ CONTAINS
         INTEGER(4), PARAMETER                   :: UnControllerParameters = 89  ! Unit number to open file
         TYPE(ControlParameters), INTENT(INOUT)  :: CntrPar                      ! Control parameter type
        
+        CHARACTER(1024)                         :: TempStr                      ! Temporary string for reading either a float or filename for Y_MErrSet
 
         OPEN(unit=UnControllerParameters, file=accINFILE(1), status='old', action='read')
         
@@ -166,7 +167,9 @@ CONTAINS
         ALLOCATE(CntrPar%Y_ErrThresh(2))
         READ(UnControllerParameters, *) CntrPar%Y_ErrThresh
         READ(UnControllerParameters, *) CntrPar%Y_Rate
-        READ(UnControllerParameters, *) CntrPar%Y_MErrSet
+       !READ(UnControllerParameters, *) CntrPar%Y_MErrSet
+        READ(UnControllerParameters, *) TempStr
+        CALL ReadYawOffset(TempStr,CntrPar)
         READ(UnControllerParameters, *) CntrPar%Y_IPC_IntSat
         READ(UnControllerParameters, *) CntrPar%Y_IPC_n
         ALLOCATE(CntrPar%Y_IPC_KP(CntrPar%Y_IPC_n))
@@ -652,4 +655,39 @@ CONTAINS
         END DO
     
     END SUBROUTINE ReadCpFile
+    ! -----------------------------------------------------------------------------------
+    ! Attempt to read a constant value for Y_MErrSet, otherwise assume that the
+    ! input is a filename
+    SUBROUTINE ReadYawOffset(TempStr,CntrPar)
+        USE ROSCO_Types, ONLY : ControlParameters
+
+        CHARACTER(1024),         INTENT(IN   ) :: TempStr
+        TYPE(ControlParameters), INTENT(INOUT) :: CntrPar
+
+        INTEGER :: istat
+        REAL(8) :: testval
+
+        READ(TempStr,*,iostat=istat) testval
+        IF ( istat /= 0 ) THEN
+            CALL ReadOffsetsFile(TempStr,CntrPar)
+        ELSE
+           !ALLOCATE(CntrPar%Y_MErrSet(1))
+            CntrPar%Y_MErrSet = testval
+        END IF
+    END SUBROUTINE ReadYawOffset
+    ! -----------------------------------------------------------------------------------
+    ! Read time history of desired yaw offset (optional) to set Y_MErrSet
+    SUBROUTINE ReadOffsetsFile(FileName,CntrPar)
+        USE ROSCO_Types, ONLY : ControlParameters
+
+        INTEGER(4), PARAMETER :: YawOffsetHist = 90
+        CHARACTER(1024),         INTENT(IN   ) :: FileName
+        TYPE(ControlParameters), INTENT(INOUT) :: CntrPar
+        ! Local variables
+        INTEGER(4)                  :: i ! iteration index
+
+        WRITE(*,*) 'THIS IS A STUB'
+       !ALLOCATE(CntrPar%Y_MErrSet(1))
+        CntrPar%Y_MErrSet = 0.0
+    END SUBROUTINE ReadOffsetsFile
 END MODULE ReadSetParameters


### PR DESCRIPTION
`Y_MErrSet` in the `DISCON.IN` can now take a scalar or a filename as input. If a filename is specified, the given file will be loaded expecting the following:
* two white-space delimited columns with time and commanded offset
* the file will be read until there are no more lines with numerical values